### PR TITLE
Checking if the challenge Id has previously been set

### DIFF
--- a/src/main/java/org/maproulette/client/batch/ProjectBatch.java
+++ b/src/main/java/org/maproulette/client/batch/ProjectBatch.java
@@ -73,7 +73,16 @@ public class ProjectBatch
             throws MapRouletteException
     {
         challenge.setParent(this.projectId);
-        final var challengeId = ChallengeBatch.getChallengeId(this.configuration, challenge);
+        final long challengeId;
+        if (challenge.getId() < 0)
+        {
+            challengeId = ChallengeBatch.getChallengeId(this.configuration, challenge);
+            challenge.setId(challengeId);
+        }
+        else
+        {
+            challengeId = challenge.getId();
+        }
         final var challengeBatch = this.batch.getOrDefault(challengeId,
                 new ChallengeBatch(this.configuration, challenge));
         task.setParent(challengeId);


### PR DESCRIPTION
### Description:

On batch uploads it was making an API request to get the challenge Id every time a task was added. This was highly inefficient and causing quite significant slow downs.

### Unit Test Approach:

Unit tests executed

### Test Results:

Unit tests passed.

------

In doubt: [Contributing Guidelines](../CONTRIBUTING.md)
