### PR TITLE
Update RuleList 'rules' to support expected types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ dependencies
     implementation packages.lombok
     annotationProcessor packages.lombok
 
+    testImplementation packages.slf4j.simple
     testImplementation packages.junit
     testImplementation packages.mockito
 
+    integrationTestImplementation packages.slf4j.simple
     integrationTestImplementation packages.junit
 
     checkstyle packages.checkstyle

--- a/src/integrationTest/java/org/maproulette/client/IntegrationBase.java
+++ b/src/integrationTest/java/org/maproulette/client/IntegrationBase.java
@@ -14,6 +14,7 @@ import org.maproulette.client.model.Project;
 public class IntegrationBase
 {
     public static final String DEFAULT_PROJECT_NAME = "IntegrationTestProject1";
+    public static final String ENVIRONMENT_SCHEME = "scheme";
     public static final String ENVIRONMENT_HOST = "host";
     public static final String ENVIRONMENT_PORT = "port";
     public static final String ENVIRONMENT_API_KEY = "apiKey";
@@ -26,6 +27,7 @@ public class IntegrationBase
             .build();
     private long defaultProjectIdentifier = -1;
     private long projectIdentifier = -1;
+    private String scheme;
     private String host;
     private int port;
     private String apiKey;
@@ -114,7 +116,7 @@ public class IntegrationBase
         if (this.configuration == null)
         {
             this.configurationParamsSetUp();
-            this.configuration = new MapRouletteConfiguration(this.host, this.port,
+            this.configuration = new MapRouletteConfiguration(this.scheme, this.host, this.port,
                     DEFAULT_PROJECT_NAME, this.apiKey);
         }
         return this.configuration;
@@ -122,6 +124,12 @@ public class IntegrationBase
 
     private void configurationParamsSetUp()
     {
+        this.scheme = System.getenv(ENVIRONMENT_SCHEME);
+        if (StringUtils.isEmpty(this.scheme))
+        {
+            this.scheme = "https";
+        }
+
         this.host = System.getenv(ENVIRONMENT_HOST);
         if (StringUtils.isEmpty(this.host))
         {

--- a/src/main/java/org/maproulette/client/model/RuleList.java
+++ b/src/main/java/org/maproulette/client/model/RuleList.java
@@ -1,18 +1,27 @@
 package org.maproulette.client.model;
 
-import java.io.Serializable;
-import java.util.List;
-
-import org.maproulette.client.exception.MapRouletteRuntimeException;
-
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.maproulette.client.exception.MapRouletteRuntimeException;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author mcuthbert
@@ -21,6 +30,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonDeserialize(using = RuleList.RuleListDeserializer.class)
+@JsonSerialize(using = RuleList.RuleListSerializer.class)
 public class RuleList implements Serializable
 {
     private static final String KEY_CONDITION = "condition";
@@ -28,6 +39,7 @@ public class RuleList implements Serializable
     private static final long serialVersionUID = -1085774480815117637L;
 
     private String condition;
+    private List<RuleList> ruleList;
     private List<PriorityRule> rules;
 
     public boolean isSet()
@@ -38,16 +50,128 @@ public class RuleList implements Serializable
     @JsonValue
     public String toJson()
     {
-        final var mapper = new ObjectMapper();
         try
         {
-            return String.format("{\"%s\":\"%s\",\"%s\":%s}", KEY_CONDITION, this.getCondition(),
-                    KEY_RULES, mapper.writeValueAsString(this.getRules()));
-        }
-        catch (final JsonProcessingException e)
+            return ObjectMapperSingleton.getMapper().writeValueAsString(this);
+        } catch (final JsonProcessingException e)
         {
             throw new MapRouletteRuntimeException(e);
         }
+    }
 
+    public static class RuleListSerializer extends StdSerializer<RuleList>
+    {
+
+        public RuleListSerializer()
+        {
+            this(null);
+        }
+
+        public RuleListSerializer(Class<RuleList> t)
+        {
+            super(t);
+        }
+
+        private static void serializeRuleListHelper(List<RuleList> ruleList, JsonGenerator gen) throws IOException
+        {
+            for (RuleList r : ruleList)
+            {
+                gen.writeStartObject();
+                gen.writeStringField("condition", r.getCondition());
+                gen.writeArrayFieldStart("rules");
+                if (r.getRuleList() != null)
+                {
+                    for (RuleList it : r.getRuleList())
+                    {
+                        serializeRuleListHelper(it.getRuleList(), gen);
+                    }
+                }
+                if (r.getRules() != null)
+                {
+                    for (PriorityRule p : r.getRules())
+                    {
+                        gen.writeObject(p);
+                    }
+                }
+                gen.writeEndArray();
+                gen.writeEndObject();
+            }
+        }
+
+        @Override
+        public void serialize(RuleList value, JsonGenerator gen, SerializerProvider serializers) throws IOException
+        {
+            gen.writeStartObject();
+            gen.writeStringField("condition", value.getCondition());
+            gen.writeArrayFieldStart("rules");
+            if (value.getRuleList() != null)
+            {
+                serializeRuleListHelper(value.getRuleList(), gen);
+            }
+
+            if (value.getRules() != null)
+            {
+                for (PriorityRule p : value.getRules())
+                {
+                    gen.writeObject(p);
+                }
+            }
+            gen.writeEndArray();
+            gen.writeEndObject();
+        }
+    }
+
+    public static class RuleListDeserializer extends StdDeserializer<RuleList>
+    {
+
+        public RuleListDeserializer()
+        {
+            this(null);
+        }
+
+        public RuleListDeserializer(final Class<?> vc)
+        {
+            super(vc);
+        }
+
+        private static RuleList buildRuleListHelper(JsonNode node, DeserializationContext ctxt)
+        {
+            if (node.get("condition") == null)
+            {
+                return null;
+            }
+            final RuleList ret = RuleList.builder()
+                    .condition(node.get("condition").asText())
+                    .ruleList(new ArrayList<>())
+                    .rules(new ArrayList<>())
+                    .build();
+
+            for (JsonNode it : node.withArray("rules"))
+            {
+                if (it.get("condition") != null)
+                {
+                    // If the child is a PriorityRule, do a recursive call to build the rule and add it to the list.
+                    RuleList child = buildRuleListHelper(it, ctxt);
+                    ret.getRuleList().add(child);
+                } else
+                {
+                    PriorityRule priorityRule = PriorityRule.builder()
+                            .type(it.get("type").asText())
+                            .operator(it.get("operator").asText())
+                            .value(it.get("value").asText())
+                            .build();
+                    ret.getRules().add(priorityRule);
+                }
+            }
+
+            return ret;
+        }
+
+        @Override
+        public RuleList deserialize(JsonParser p, DeserializationContext ctxt) throws IOException
+        {
+            JsonNode node = p.getCodec().readTree(p);
+            return buildRuleListHelper(node, ctxt);
+        }
     }
 }

--- a/src/main/java/org/maproulette/client/utilities/ObjectMapperSingleton.java
+++ b/src/main/java/org/maproulette/client/utilities/ObjectMapperSingleton.java
@@ -1,0 +1,30 @@
+package org.maproulette.client.utilities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.maproulette.client.model.RuleList;
+
+public class ObjectMapperSingleton
+{
+    private static volatile ObjectMapper mapper;
+
+    public static ObjectMapper getMapper()
+    {
+        if (mapper == null)
+        {
+            synchronized (ObjectMapper.class)
+            {
+                if (mapper == null)
+                {
+                    mapper = new ObjectMapper();
+                    SimpleModule module = new SimpleModule();
+                    module.addSerializer(RuleList.class, new RuleList.RuleListSerializer());
+                    module.addDeserializer(RuleList.class, new RuleList.RuleListDeserializer());
+                    mapper.registerModule(module);
+                }
+            }
+        }
+
+        return mapper;
+    }
+}

--- a/src/main/java/org/maproulette/client/utilities/Utilities.java
+++ b/src/main/java/org/maproulette/client/utilities/Utilities.java
@@ -1,10 +1,8 @@
 package org.maproulette.client.utilities;
 
-import java.io.IOException;
-
 import org.maproulette.client.exception.MapRouletteException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 
 /**
  * A generic helper class
@@ -18,8 +16,7 @@ public final class Utilities
     {
         try
         {
-            final var mapper = new ObjectMapper();
-            return mapper.readValue(json, clazz);
+            return ObjectMapperSingleton.getMapper().readValue(json, clazz);
         }
         catch (final IOException e)
         {

--- a/src/test/java/org/maproulette/client/serializer/ChallengeSerializationTest.java
+++ b/src/test/java/org/maproulette/client/serializer/ChallengeSerializationTest.java
@@ -1,6 +1,7 @@
 package org.maproulette.client.serializer;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
@@ -13,6 +14,7 @@ import org.maproulette.client.model.PriorityRule;
 import org.maproulette.client.model.RuleList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 /**
  * Tests whether a challenge can be read correctly from resources.
@@ -24,7 +26,7 @@ public class ChallengeSerializationTest
     private static final String DESCRIPTION = "DESCRIPTION";
     private static final String BLURB = "BLURB";
     private static final String INSTRUCTION = "INSTRUCTION";
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
 
     @Test
     public void fullSerializationTest() throws IOException
@@ -147,10 +149,12 @@ public class ChallengeSerializationTest
         final var highPriority = RuleList.builder().condition("AND")
                 .rules(Collections.singletonList(PriorityRule.builder().operator("equal")
                         .type("string").value("priority_pd.3").build()))
+                .ruleList(new ArrayList<>())
                 .build();
         final var mediumPriority = RuleList.builder().condition("OR")
                 .rules(Collections.singletonList(PriorityRule.builder().operator("equal")
                         .type("string").value("priority_pd.2").build()))
+                .ruleList(new ArrayList<>())
                 .build();
 
         Assertions.assertEquals(DESCRIPTION, deserializedChallenge.getDescription());

--- a/src/test/java/org/maproulette/client/serializer/RuleListSerializationDeserializationTest.java
+++ b/src/test/java/org/maproulette/client/serializer/RuleListSerializationDeserializationTest.java
@@ -1,0 +1,112 @@
+package org.maproulette.client.serializer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.maproulette.client.model.PriorityRule;
+import org.maproulette.client.model.RuleList;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class RuleListSerializationDeserializationTest
+{
+    private static RuleList stringJsonToRuleList(final String in) throws IOException
+    {
+        return ObjectMapperSingleton.getMapper().readValue(in, RuleList.class);
+    }
+
+    private static RuleList resourceToRuleList(String resource) throws IOException
+    {
+        return stringJsonToRuleList(SerializerUtilities.getResourceAsString(resource));
+    }
+
+    @Test
+    public void empty() throws IOException
+    {
+        Assertions.assertNull(stringJsonToRuleList("{}"));
+    }
+
+    @Test
+    public void noRules() throws IOException
+    {
+        RuleList expected = RuleList.builder().condition("OR").rules(new ArrayList<>()).ruleList(new ArrayList<>()).build();
+        RuleList actual = resourceToRuleList("rulelist/rulelist_condition_no_rules.json");
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void simpleRules() throws IOException
+    {
+        RuleList expected = RuleList.builder()
+                .condition("AND")
+                .rules(
+                        Collections.singletonList(
+                                PriorityRule.builder()
+                                        .value("priority_pd.3")
+                                        .type("string")
+                                        .operator("equal")
+                                        .build()))
+                .ruleList(new ArrayList<>())
+                .build();
+        RuleList actual = resourceToRuleList("rulelist/rulelist_priorityrule_not_nested.json");
+        Assertions.assertEquals(expected, actual);
+        Assertions.assertEquals(stringJsonToRuleList(ObjectMapperSingleton.getMapper().writeValueAsString(expected)), expected);
+    }
+
+    @Test
+    public void nestedRuleList() throws IOException
+    {
+        RuleList expected = RuleList.builder()
+                .condition("AND")
+                .rules(new ArrayList<>())
+                .ruleList(Collections.singletonList(
+                        RuleList.builder()
+                                .condition("OR")
+                                .ruleList(new ArrayList<>())
+                                .rules(Collections.singletonList(
+                                        PriorityRule.builder()
+                                                .value("a.b")
+                                                .type("string")
+                                                .operator("is_not_empty")
+                                                .build()))
+                                .build()))
+                .build();
+        RuleList actual = resourceToRuleList("rulelist/rulelist_no_priorityrule_with_nested_rulelist.json");
+        Assertions.assertEquals(expected, actual);
+        Assertions.assertEquals(stringJsonToRuleList(ObjectMapperSingleton.getMapper().writeValueAsString(expected)), expected);
+    }
+
+    @Test
+    public void nestedWithPriorityRuleAndRuleList() throws IOException
+    {
+        RuleList expected = RuleList.builder()
+                .condition("AND")
+                .rules(Collections.singletonList(
+                        PriorityRule.builder()
+                                .value("t.u")
+                                .type("string")
+                                .operator("is_empty")
+                                .build()
+                ))
+                .ruleList(Collections.singletonList(
+                        RuleList.builder()
+                                .condition("OR")
+                                .ruleList(new ArrayList<>())
+                                .rules(Collections.singletonList(
+                                        PriorityRule.builder()
+                                                .value("a.b")
+                                                .type("string")
+                                                .operator("is_not_empty")
+                                                .build()))
+                                .build()))
+                .build();
+        RuleList actual = resourceToRuleList("rulelist/rulelist_priorityrule_with_nested_rulelist.json");
+        RuleList actual_reordered = resourceToRuleList("rulelist/rulelist_priorityrule_with_nested_rulelist_reordered.json");
+        Assertions.assertEquals(expected, actual);
+        Assertions.assertEquals(stringJsonToRuleList(ObjectMapperSingleton.getMapper().writeValueAsString(expected)), expected);
+        Assertions.assertEquals(expected, actual_reordered);
+    }
+
+}

--- a/src/test/resources/rulelist/rulelist_condition_no_rules.json
+++ b/src/test/resources/rulelist/rulelist_condition_no_rules.json
@@ -1,0 +1,4 @@
+{
+  "condition": "OR",
+  "rules": []
+}

--- a/src/test/resources/rulelist/rulelist_no_priorityrule_with_nested_rulelist.json
+++ b/src/test/resources/rulelist/rulelist_no_priorityrule_with_nested_rulelist.json
@@ -1,0 +1,15 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "condition": "OR",
+      "rules": [
+        {
+          "value": "a.b",
+          "type": "string",
+          "operator": "is_not_empty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/rulelist/rulelist_priorityrule_not_nested.json
+++ b/src/test/resources/rulelist/rulelist_priorityrule_not_nested.json
@@ -1,0 +1,10 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "value": "priority_pd.3",
+      "type": "string",
+      "operator": "equal"
+    }
+  ]
+}

--- a/src/test/resources/rulelist/rulelist_priorityrule_with_nested_rulelist.json
+++ b/src/test/resources/rulelist/rulelist_priorityrule_with_nested_rulelist.json
@@ -1,0 +1,20 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "value": "t.u",
+      "type": "string",
+      "operator": "is_empty"
+    },
+    {
+      "condition": "OR",
+      "rules": [
+        {
+          "value": "a.b",
+          "type": "string",
+          "operator": "is_not_empty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/rulelist/rulelist_priorityrule_with_nested_rulelist_reordered.json
+++ b/src/test/resources/rulelist/rulelist_priorityrule_with_nested_rulelist_reordered.json
@@ -1,0 +1,20 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "condition": "OR",
+      "rules": [
+        {
+          "value": "a.b",
+          "type": "string",
+          "operator": "is_not_empty"
+        }
+      ]
+    },
+    {
+      "value": "t.u",
+      "type": "string",
+      "operator": "is_empty"
+    }
+  ]
+}


### PR DESCRIPTION
### Description:

The scala API allows the RuleList 'rules' to be either a RuleList or a PriorityRule, with recursive nesting possible on the RuleLists.
This patch adds (de)serialization support of the RuleList objects
written by the scala backend. The previous java code allowed only the
PriorityRule as the child of a RuleList.

For example, the below JSON is a RuleList with rules being PriorityRule
and a nested RuleList:
client code:
```
{
  "condition": "AND",
  "rules": [
    { // priority rule
      "value": "t.u",
      "type": "string",
      "operator": "is_empty"
    },
    { // rule list
      "condition": "OR",
      "rules": [
        {
          "value": "a.b",
          "type": "string",
          "operator": "is_not_empty"
        }
      ]
    }
  ]
}
```

### Unit Test Approach:

This patch is tested by taking a RuleList as json and deserializing to the RuleList Java object and verifying it matches the expected object. The test will then take the RuleList java object, convert to string, convert back to object and verify the objects still match.

### Test Results:

The ObjectMapper ctor call in a few places was replaced with a static ObjectMapperSingleton.getMapper(), since modules were registered and typically a cached mapper should be used.

------

In doubt: [Contributing Guidelines](../CONTRIBUTING.md)
