### PR TITLE
add errorTags field to Task object

### DIFF
--- a/src/main/java/org/maproulette/client/model/Task.java
+++ b/src/main/java/org/maproulette/client/model/Task.java
@@ -98,7 +98,7 @@ public class Task implements IMapRouletteObject, Serializable
             this.errorTags = errorTags;
             return this;
         }
-        
+
         public TaskBuilder resetGeometry()
         {
             this.geoJson = this.mapper.createArrayNode();
@@ -134,12 +134,13 @@ public class Task implements IMapRouletteObject, Serializable
             {
                 this.parent(-1);
             }
-            if(this.errorTags == null)
+            if (this.errorTags == null)
             {
                 this.errorTags = "";
             }
             return new Task(this.id, this.parent, this.name, this.instruction, this.location,
-                    this.status, this.priority, this.geometries, this.tags, null, null, null, this.errorTags);
+                    this.status, this.priority, this.geometries, this.tags, null, null, null,
+                    this.errorTags);
         }
 
         protected ArrayNode generateTaskFeatures(final Set<PointInformation> source,

--- a/src/main/java/org/maproulette/client/model/Task.java
+++ b/src/main/java/org/maproulette/client/model/Task.java
@@ -93,6 +93,12 @@ public class Task implements IMapRouletteObject, Serializable
             return this;
         }
 
+        public TaskBuilder addErrorTags(final String errorTags)
+        {
+            this.errorTags = errorTags;
+            return this;
+        }
+        
         public TaskBuilder resetGeometry()
         {
             this.geoJson = this.mapper.createArrayNode();
@@ -128,8 +134,12 @@ public class Task implements IMapRouletteObject, Serializable
             {
                 this.parent(-1);
             }
+            if(this.errorTags == null)
+            {
+                this.errorTags = "";
+            }
             return new Task(this.id, this.parent, this.name, this.instruction, this.location,
-                    this.status, this.priority, this.geometries, this.tags, null, null, null);
+                    this.status, this.priority, this.geometries, this.tags, null, null, null, this.errorTags);
         }
 
         protected ArrayNode generateTaskFeatures(final Set<PointInformation> source,
@@ -204,6 +214,7 @@ public class Task implements IMapRouletteObject, Serializable
     private Long completedBy;
     private Long completedTimeSpent;
     private String mappedOn;
+    private String errorTags;
 
     public static TaskBuilder builder(final long parentIdentifier, final String name)
     {

--- a/src/test/java/org/maproulette/client/model/TaskTest.java
+++ b/src/test/java/org/maproulette/client/model/TaskTest.java
@@ -96,8 +96,7 @@ public class TaskTest
         final List<String> testTags = Arrays.asList("fixtype=testing", "usecase=1");
         final var task = Task.builder(1234, "Task1")
                 .addGeojson(String.format(TestConstants.FEATURE_STRING, 1.2, 4.5, "TestG"))
-                .errorTags("dummyErrorTags")
-                .tags(testTags).build();
+                .errorTags("dummyErrorTags").tags(testTags).build();
         Assertions.assertEquals("dummyErrorTags", task.getErrorTags());
     }
 
@@ -108,6 +107,6 @@ public class TaskTest
         final var task = Task.builder(1234, "Task1")
                 .addGeojson(String.format(TestConstants.FEATURE_STRING, 1.2, 4.5, "TestG"))
                 .tags(testTags).build();
-        Assertions.assertEquals( "", task.getErrorTags());
+        Assertions.assertEquals("", task.getErrorTags());
     }
 }

--- a/src/test/java/org/maproulette/client/model/TaskTest.java
+++ b/src/test/java/org/maproulette/client/model/TaskTest.java
@@ -89,4 +89,25 @@ public class TaskTest
         task2 = task2.toBuilder().name("Task2").build();
         Assertions.assertNotEquals(task1.hashCode(), task2.hashCode());
     }
+
+    @Test
+    public void taskWithErrorTags()
+    {
+        final List<String> testTags = Arrays.asList("fixtype=testing", "usecase=1");
+        final var task = Task.builder(1234, "Task1")
+                .addGeojson(String.format(TestConstants.FEATURE_STRING, 1.2, 4.5, "TestG"))
+                .errorTags("dummyErrorTags")
+                .tags(testTags).build();
+        Assertions.assertEquals("dummyErrorTags", task.getErrorTags());
+    }
+
+    @Test
+    public void taskWithoutErrorTags()
+    {
+        final List<String> testTags = Arrays.asList("fixtype=testing", "usecase=1");
+        final var task = Task.builder(1234, "Task1")
+                .addGeojson(String.format(TestConstants.FEATURE_STRING, 1.2, 4.5, "TestG"))
+                .tags(testTags).build();
+        Assertions.assertEquals( "", task.getErrorTags());
+    }
 }


### PR DESCRIPTION
### Description:

I added new field - errorTags to Task object. It is related to Task model in MapRoulette API: https://maproulette.org/docs/swagger-ui/index.html?url=/assets/swagger.json#/Task/create
It probably also resolves issue: https://github.com/osmlab/maproulette-java-client/issues/67

### Unit Test Approach:

There were added two unit tests which verify if TaskBuilder correctly handles adding errorTags.

### Test Results:

There were no impact on other tests
