### PR TITLE
Fix method name 'MapRouletteConnection.getRequestBodyAsString'

### DIFF
--- a/src/main/java/org/maproulette/client/connection/MapRouletteConnection.java
+++ b/src/main/java/org/maproulette/client/connection/MapRouletteConnection.java
@@ -71,7 +71,7 @@ public class MapRouletteConnection implements IMapRouletteConnection
                     {
                         case HttpStatus.SC_OK:
                         case HttpStatus.SC_CREATED:
-                            final String ret = resource.getRequestBodyAsString();
+                            final String ret = resource.getResponseBodyAsString();
                             log.trace("Response body: {}", ret);
                             return ret;
                         case HttpStatus.SC_NO_CONTENT:
@@ -80,7 +80,7 @@ public class MapRouletteConnection implements IMapRouletteConnection
                         default:
                             throw new MapRouletteException(
                                     String.format("Invalid response status code %d - %s",
-                                            statusCode, resource.getRequestBodyAsString()));
+                                            statusCode, resource.getResponseBodyAsString()));
                     }
                 }));
     }

--- a/src/main/java/org/maproulette/client/http/HttpResource.java
+++ b/src/main/java/org/maproulette/client/http/HttpResource.java
@@ -95,7 +95,7 @@ public abstract class HttpResource implements Closeable
         return this.response.getHeaders(headerKey);
     }
 
-    public String getRequestBodyAsString() throws MapRouletteException
+    public String getResponseBodyAsString() throws MapRouletteException
     {
         try
         {

--- a/src/test/java/org/maproulette/client/connection/MapRouletteConnectionTest.java
+++ b/src/test/java/org/maproulette/client/connection/MapRouletteConnectionTest.java
@@ -62,7 +62,7 @@ public class MapRouletteConnectionTest
         when(deleteResource.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND)
                 .thenReturn(HttpStatus.SC_NO_CONTENT).thenReturn(HttpStatus.SC_OK)
                 .thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(deleteResource.getRequestBodyAsString()).thenReturn("test");
+        when(deleteResource.getResponseBodyAsString()).thenReturn("test");
         final var query = Query.builder().delete("").build();
         Assertions.assertTrue(connection.execute(query).isEmpty());
         Assertions.assertTrue(connection.execute(query).isEmpty());
@@ -80,7 +80,7 @@ public class MapRouletteConnectionTest
         when(getResource.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND)
                 .thenReturn(HttpStatus.SC_NO_CONTENT).thenReturn(HttpStatus.SC_OK);
         final var responseString = "{\"test\":\"test\"}";
-        when(getResource.getRequestBodyAsString()).thenReturn(responseString);
+        when(getResource.getResponseBodyAsString()).thenReturn(responseString);
 
         final var query = Query.builder().get("").build();
         // First request will respond with NOT_FOUND
@@ -103,7 +103,7 @@ public class MapRouletteConnectionTest
         final var postResource = factory.resource(HttpPost.METHOD_NAME);
         when(postResource.getStatusCode()).thenReturn(HttpStatus.SC_CREATED)
                 .thenReturn(HttpStatus.SC_OK).thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(postResource.getRequestBodyAsString()).thenReturn("{\"id\":1234}")
+        when(postResource.getResponseBodyAsString()).thenReturn("{\"id\":1234}")
                 .thenReturn("{\"id\":6543}");
         final var query = Query.builder().post("").build();
         Assertions.assertEquals(Optional.of("{\"id\":1234}"), connection.execute(query));


### PR DESCRIPTION
### Description:

The `MapRouletteConnection.getRequestBodyAsString()` method was getting the _response_ body, and the method name now reflects that (renamed to `getResponseBodyAsString()`).

This change will break API users that happened to inherit or use the `MapRouletteConnection.getRequestBodyAsString()`.

### Unit Test Approach:

N/A

### Test Results:

Tests pass,
