### PR TITLE
Configure and document the simplelogger.properties for easier debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,16 +52,13 @@ Once you have fixed an issue or added a new feature, it is time to submit [a pul
 Building MapRoulette Java Client can be simply done using gradle:
 `./gradlew clean build`
 
-#### Log4j Properties
+#### Log Levels
 
-Make sure you first have a `log4j.properties` file in `src/main/resources`. 
-Alternatively, you can have as a VM parameter:
+The unit tests and integration tests use the `slf4j-simple` logging framework.
 
-``` 
--Dlog4j.configuration=file://<path_to_config>
-```
+The log level defaults to `info` and can be changed within the test resources `./src/test/resources/simplelogger.properties`.
+Logging at the `trace` level will log all HTTP requests (and payloads) and all HTTP responeses (and payloads).
 
-https://github.com/osmlab/maproulette-java-client/blob/dev/config/log4j/log4j.properties
 
 #### IntelliJ Setup
 
@@ -76,6 +73,8 @@ There also is an eclipse code formatting template [here](config/format/code_form
 ### Testing
 
 The codebase contains an extensive range of unit tests. Unit tests are supposed to run fairly fast. All the tests will be run for every pull request build, so make sure that it doesn't take an exceptionally long time to run! When contributing new code, make sure to not break existing tests (or modify them and explain why the modification is needed) and to add new tests for new features.
+
+Using the `trace` logging level may help in finding the root cause of a test failure.
 
 ### Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The MapRoulette Java Client is a java library that makes it easy to create Proje
 
 ### Contributing
 
-For contributing guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
+For contributing guidelines see [CONTRIBUTING.md](CONTRIBUTING.md). These guidelines are essential for anyone providing code contributions.
 
 ### API
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,6 @@ project.ext.packages = [
     slf4j: [
         api: "org.slf4j:slf4j-api:${versions.slf4j}",
         simple: "org.slf4j:slf4j-simple:${versions.slf4j}",
-        log4j12: "org.slf4j:slf4j-log4j12:${versions.slf4j}",
     ],
     http: "org.apache.httpcomponents:httpclient:${versions.http}",
     checkstyle: "com.puppycrawl.tools:checkstyle:${versions.checkstyle}",

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+# Change the logging level to 'trace' to view all HTTP request data and response data.
+org.slf4j.simpleLogger.defaultLogLevel=info


### PR DESCRIPTION
### Description:

The unit tests and integration tests use `slf4j-simple` as the logging framework but it is not obvious how to change the logging levels. To help with that, this patch creates the `simplelogger.properties` file at the `info` level by default and notes in the readme how to get more verbose output in the tests.

### Unit Test Approach:

N/A, docs.

### Test Results:

N/A
