### PR TITLE
Enable spotbugs scans and do not fail the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 	id 'jacoco'
 	id "com.diffplug.gradle.spotless" version "3.27.0"
 	id 'org.sonarqube' version '2.8'
+	id "com.github.spotbugs" version "4.8.0"
 }
 
 apply from: 'dependencies.gradle'

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -8,6 +8,16 @@ checkstyle
     toolVersion = versions.checkstyle
 }
 
+spotbugs {
+    ignoreFailures = true
+}
+spotbugsMain {
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+}
+
 sourceSets
 {
     integrationTest


### PR DESCRIPTION
### Description:

Enable spotbugs scans and do not fail the build. The findings are helpful for contributors' code quality.
In the future, after all findings are resolved, the build should fail if an issue is introduced.

### Unit Test Approach:

N/A, build enhancement.

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](../CONTRIBUTING.md)
