### PR TITLE
Allow integration tests to be ran

### DIFF
--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -33,11 +33,12 @@ test
 }
 
 task integrationTest(type: Test) {
+    useJUnitPlatform()
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     testLogging
     {
-        events "failed"
+        events "passed", "skipped", "failed"
         exceptionFormat = 'full'
     }
 }


### PR DESCRIPTION

### Description:

Junit5 was not configured for the integration tests, and this was fixed.
Run the tests with

```
host=127.0.0.1 scheme=http apiKey=1234 \
  ./gradlew --info --no-daemon --project-prop runIntegrationTests \
  clean integrationTest \
  --tests '*BatchUploaderIntegrationTest*' \
  --tests '*ChallengeAPIIntegrationTest*'
```

### Unit Test Approach:

N/A

### Test Results:

The integration tests will be scanned and will run correctly.
