### PR TITLE
Avoid unnecessary http requests due to map getOrDefault

### DIFF
--- a/src/main/java/org/maproulette/client/batch/BatchUploader.java
+++ b/src/main/java/org/maproulette/client/batch/BatchUploader.java
@@ -88,8 +88,11 @@ public class BatchUploader
         {
             identifier = this.getDefaultProjectIdentifier();
         }
-        final var projectBatch = this.projectBatchMap.getOrDefault(identifier,
-                new ProjectBatch(identifier, this.configuration));
+
+        final long finalIdentifier = identifier;
+        final var projectBatch = this.projectBatchMap.computeIfAbsent(identifier,
+                k -> new ProjectBatch(finalIdentifier, this.configuration));
+
         final var challengeId = projectBatch.addTask(challenge, task);
         this.projectBatchMap.put(identifier, projectBatch);
         return new Tuple<>(identifier, challengeId);
@@ -131,6 +134,16 @@ public class BatchUploader
         });
     }
 
+    /**
+     * Get the project id for the configuration's default project name. If the project id is not yet
+     * known, HTTP requests will be make to (1) get the default project and (2) if the default
+     * project doesn't exist create it. <br>
+     * THIS METHOD MAY MAKE EXTERNAL HTTP REQUESTS. <br>
+     *
+     * @return project id
+     * @throws MapRouletteException
+     *             when the requests fail
+     */
     private long getDefaultProjectIdentifier() throws MapRouletteException
     {
         if (this.defaultProjectIdentifier == -1)

--- a/src/main/java/org/maproulette/client/batch/ChallengeBatch.java
+++ b/src/main/java/org/maproulette/client/batch/ChallengeBatch.java
@@ -15,6 +15,7 @@ import org.maproulette.client.exception.MapRouletteException;
 import org.maproulette.client.exception.MapRouletteRuntimeException;
 import org.maproulette.client.model.Challenge;
 import org.maproulette.client.model.Task;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class ChallengeBatch
 {
     private static final int MAXIMUM_BATCH_SIZE = 5000;
     private final Logger logger = LoggerFactory.getLogger(ChallengeBatch.class);
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
     private final IMapRouletteConnection connection;
     private final long challengeId;
     private final int maxBatchSize;
@@ -116,6 +117,8 @@ public class ChallengeBatch
         this.batch.add(task);
         if (this.batch.size() >= this.maxBatchSize)
         {
+            this.logger.debug("FLUSHING queued tasks as batch size {} meets max {}",
+                    this.batch.size(), this.maxBatchSize);
             this.flush();
         }
     }

--- a/src/main/java/org/maproulette/client/batch/ProjectBatch.java
+++ b/src/main/java/org/maproulette/client/batch/ProjectBatch.java
@@ -83,8 +83,10 @@ public class ProjectBatch
         {
             challengeId = challenge.getId();
         }
-        final var challengeBatch = this.batch.getOrDefault(challengeId,
-                new ChallengeBatch(this.configuration, challenge));
+
+        final var challengeBatch = this.batch.computeIfAbsent(challengeId,
+                k -> new ChallengeBatch(this.configuration, challenge));
+
         task.setParent(challengeId);
         challengeBatch.addTask(task);
         this.batch.put(challengeId, challengeBatch);

--- a/src/main/java/org/maproulette/client/connection/MapRouletteConnection.java
+++ b/src/main/java/org/maproulette/client/connection/MapRouletteConnection.java
@@ -57,7 +57,11 @@ public class MapRouletteConnection implements IMapRouletteConnection
     @Override
     public Optional<String> execute(final Query query) throws MapRouletteException
     {
-        log.trace("Request: {} {} data={}", query.getMethodName(), query.getUri(), query.getData());
+        log.debug("Request: {} {}", query.getMethodName(), query.getUri());
+        if (log.isTraceEnabled())
+        {
+            log.trace("data={}", query.getData());
+        }
 
         // add authentication to the query
         query.addHeader(KEY_API_KEY, this.configuration.getApiKey());


### PR DESCRIPTION
### Description:

The task batch upload is causing O(n) HTTP additional calls due to a constructor being called in a `map.getOrDefault`. Resolve by using `computeIfAbsent` to defer the construction to when it is needed.

For example, a batch upload of 10k tasks at a bulk of 5k tasks at a time was making an additional 10,000 http connections.

### Unit Test Approach:

N/A

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](../CONTRIBUTING.md)
