### PR TITLE
Use a shared ObjectMapper instance

### DIFF
--- a/src/integrationTest/java/org/maproulette/client/api/TaskAPIIntegrationTest.java
+++ b/src/integrationTest/java/org/maproulette/client/api/TaskAPIIntegrationTest.java
@@ -11,8 +11,8 @@ import org.maproulette.client.model.Challenge;
 import org.maproulette.client.model.ChallengePriority;
 import org.maproulette.client.model.Task;
 import org.maproulette.client.model.TaskStatus;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 /**
@@ -119,7 +119,7 @@ public class TaskAPIIntegrationTest extends IntegrationBase
                 .addGeojson(String.format(TestConstants.FEATURE_STRING, 3.1, 4.2, UPDATED_GEOMETRY))
                 .build();
 
-        final ObjectMapper mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final ArrayNode arrayNode = mapper.createArrayNode();
         Assertions.assertNotNull(created.get().getGeometries().get(TASK_FEATURES).get(0));
         Assertions.assertNotNull(update.getGeometries().get(TASK_FEATURES).get(0));

--- a/src/main/java/org/maproulette/client/api/ChallengeAPI.java
+++ b/src/main/java/org/maproulette/client/api/ChallengeAPI.java
@@ -13,6 +13,7 @@ import org.maproulette.client.connection.Query;
 import org.maproulette.client.exception.MapRouletteException;
 import org.maproulette.client.model.Challenge;
 import org.maproulette.client.model.Task;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChallengeAPI implements IAPI<Challenge>
 {
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
     private final IMapRouletteConnection connection;
 
     public ChallengeAPI(final MapRouletteConfiguration configuration)

--- a/src/main/java/org/maproulette/client/api/ProjectAPI.java
+++ b/src/main/java/org/maproulette/client/api/ProjectAPI.java
@@ -13,6 +13,7 @@ import org.maproulette.client.connection.Query;
 import org.maproulette.client.exception.MapRouletteException;
 import org.maproulette.client.model.Challenge;
 import org.maproulette.client.model.Project;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProjectAPI implements IAPI<Project>
 {
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
     private final IMapRouletteConnection connection;
 
     public ProjectAPI(final MapRouletteConfiguration configuration)

--- a/src/main/java/org/maproulette/client/api/TaskAPI.java
+++ b/src/main/java/org/maproulette/client/api/TaskAPI.java
@@ -12,6 +12,7 @@ import org.maproulette.client.connection.MapRouletteConnection;
 import org.maproulette.client.connection.Query;
 import org.maproulette.client.exception.MapRouletteException;
 import org.maproulette.client.model.Task;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TaskAPI implements IAPI<Task>
 {
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
     private final IMapRouletteConnection connection;
 
     public TaskAPI(final MapRouletteConfiguration configuration)

--- a/src/main/java/org/maproulette/client/api/UserAPI.java
+++ b/src/main/java/org/maproulette/client/api/UserAPI.java
@@ -10,6 +10,7 @@ import org.maproulette.client.connection.MapRouletteConnection;
 import org.maproulette.client.connection.Query;
 import org.maproulette.client.exception.MapRouletteException;
 import org.maproulette.client.model.User;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -24,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class UserAPI
 {
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
     private final IMapRouletteConnection connection;
 
     public UserAPI(final MapRouletteConfiguration configuration)

--- a/src/main/java/org/maproulette/client/model/Task.java
+++ b/src/main/java/org/maproulette/client/model/Task.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.maproulette.client.exception.MapRouletteException;
 import org.maproulette.client.exception.MapRouletteRuntimeException;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 import org.maproulette.client.utilities.Utilities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -51,7 +52,7 @@ public class Task implements IMapRouletteObject, Serializable
         private static final String TASK_FEATURE_PROPERTIES = "properties";
         private static final String FEATURE = "feature";
         private static final String POINT = "point";
-        private final ObjectMapper mapper = new ObjectMapper();
+        private final ObjectMapper mapper = ObjectMapperSingleton.getMapper();
         private final Set<PointInformation> points = new HashSet<>();
         private ArrayNode geoJson = this.mapper.createArrayNode();
 

--- a/src/test/java/org/maproulette/client/batch/ChallengeBatchTest.java
+++ b/src/test/java/org/maproulette/client/batch/ChallengeBatchTest.java
@@ -16,10 +16,10 @@ import org.maproulette.client.api.QueryConstants;
 import org.maproulette.client.connection.MapRouletteConnection;
 import org.maproulette.client.connection.Query;
 import org.maproulette.client.model.Task;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 import org.mockito.ArgumentCaptor;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author mcuthbert
@@ -38,7 +38,7 @@ public class ChallengeBatchTest
         challengeBatch.addTasks(multipleTasks);
         challengeBatch.flush();
 
-        final var mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final var postData = mapper.createArrayNode();
         final var tasks = Arrays.asList(this.task("Task1", 12), this.task("Task2", 12),
                 this.task("Task3", 12), this.task("Task4", 12), this.task("task5", 12));

--- a/src/test/java/org/maproulette/client/serializer/ProjectSerializationTest.java
+++ b/src/test/java/org/maproulette/client/serializer/ProjectSerializationTest.java
@@ -5,8 +5,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.maproulette.client.model.Project;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 /**
  * Tests serialization and deserialization of the {@link Project} object
@@ -18,7 +17,7 @@ public class ProjectSerializationTest
     @Test
     public void projectSerializationTest() throws IOException
     {
-        final var mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final var project = Project.builder().name("TestProject").description("TestDescription")
                 .displayName("TestDisplayName").enabled(true).id(6875L).build();
         final var projectJson = mapper.writeValueAsString(project);
@@ -30,7 +29,7 @@ public class ProjectSerializationTest
     @Test
     public void fromJsonTest() throws Exception
     {
-        final var mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final var project = Project.builder().name("TestProject").description("TestDescription")
                 .displayName("TestDisplayName").enabled(true).id(6875L).build();
         final var projectJson = mapper.writeValueAsString(project);

--- a/src/test/java/org/maproulette/client/serializer/TaskSerializerTest.java
+++ b/src/test/java/org/maproulette/client/serializer/TaskSerializerTest.java
@@ -10,8 +10,7 @@ import org.maproulette.client.model.ChallengePriority;
 import org.maproulette.client.model.PointInformation;
 import org.maproulette.client.model.Task;
 import org.maproulette.client.model.TaskStatus;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.maproulette.client.utilities.ObjectMapperSingleton;
 
 /**
  * @author mcuthbert
@@ -22,7 +21,7 @@ public class TaskSerializerTest
     public void serializationTest() throws IOException
     {
         final var testFeatureString = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[%s, %s]},\"properties\": {\"name\":\"%s\"}}";
-        final var mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final var pointList = Arrays.asList(new PointInformation(1.0, 2.0),
                 new PointInformation(5.4, 8.7));
 
@@ -41,7 +40,7 @@ public class TaskSerializerTest
     public void geometriesSerializationTest() throws IOException
     {
         final var testFeatureString = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[%s, %s]},\"properties\": {\"name\":\"%s\"}}";
-        final var mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final var task = Task.builder(343444454, "TestTask").id(12355655)
                 .instruction("TestInstruction").priority(ChallengePriority.HIGH)
                 .status(TaskStatus.DELETED)
@@ -56,7 +55,7 @@ public class TaskSerializerTest
     public void fromJsonTest() throws Exception
     {
         final var testFeatureString = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[%s, %s]},\"properties\": {\"name\":\"%s\"}}";
-        final var mapper = new ObjectMapper();
+        final var mapper = ObjectMapperSingleton.getMapper();
         final var pointList = Arrays.asList(new PointInformation(1.0, 2.0),
                 new PointInformation(5.4, 8.7));
 


### PR DESCRIPTION
### Description:

The object mapper may have custom modules applied and it is best to use a single shared instance.

### Unit Test Approach:

N/A for this patch, no tests added.

### Test Results:

Pass.

