### PR TITLE
Improve the validation of rule lists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ plugins {
 	id "com.diffplug.gradle.spotless" version "3.27.0"
 	id 'org.sonarqube' version '2.8'
 	id "com.github.spotbugs" version "4.8.0"
+
+	// Lombok plugin and gradle compat matrix https://stackoverflow.com/a/63736421
+	id "io.freefair.lombok" version "5.0.1"
 }
 
 apply from: 'dependencies.gradle'

--- a/src/integrationTest/java/org/maproulette/client/api/ChallengeAPIIntegrationTest.java
+++ b/src/integrationTest/java/org/maproulette/client/api/ChallengeAPIIntegrationTest.java
@@ -80,7 +80,7 @@ public class ChallengeAPIIntegrationTest extends IntegrationBase
                 .name("UpdatedName").defaultPriority(ChallengePriority.LOW)
                 .highPriorityRule(this.getRuleList("OR", "pr.high"))
                 .mediumPriorityRule(this.getRuleList("AND", "pr.medium"))
-                .lowPriorityRule(this.getRuleList("or", "pr.low")).defaultZoom(11).minZoom(10)
+                .lowPriorityRule(this.getRuleList("OR", "pr.low")).defaultZoom(11).minZoom(10)
                 .maxZoom(12).defaultBasemapId("defaultBaseMap").defaultBasemap(67)
                 .customBasemap("customBasemap").build();
 
@@ -115,6 +115,7 @@ public class ChallengeAPIIntegrationTest extends IntegrationBase
                 updatedChallenge.getDefaultBasemap());
         Assertions.assertNotEquals(createdChallenge.getCustomBasemap(),
                 updatedChallenge.getCustomBasemap());
+        Assertions.assertTrue(updatedChallenge.getHighPriorityRule().getCondition().equals("OR"));
     }
 
     @Test
@@ -164,8 +165,9 @@ public class ChallengeAPIIntegrationTest extends IntegrationBase
     private RuleList getRuleList(final String condition, final String value)
     {
         return RuleList.builder().condition(condition).rules(Collections.singletonList(
-                PriorityRule.builder().operator("equals").type("string").value(value).build()))
+                PriorityRule.builder().operator("equal").type("string").value(value).build()))
                 .build();
+
     }
 
     private void compareChallenges(final Challenge challenge1, final Challenge challenge2)

--- a/src/main/java/org/maproulette/client/exception/MapRouletteRuntimeParseException.java
+++ b/src/main/java/org/maproulette/client/exception/MapRouletteRuntimeParseException.java
@@ -1,0 +1,24 @@
+package org.maproulette.client.exception;
+
+/**
+ * An exception class used to identify, mostly, json parsing errors.
+ * 
+ * @author ljdelight
+ */
+public class MapRouletteRuntimeParseException extends MapRouletteRuntimeException
+{
+    public MapRouletteRuntimeParseException(final Throwable e)
+    {
+        super(e);
+    }
+
+    public MapRouletteRuntimeParseException(final String message, final Throwable e)
+    {
+        super(message, e);
+    }
+
+    public MapRouletteRuntimeParseException(final String message)
+    {
+        super(message);
+    }
+}

--- a/src/main/java/org/maproulette/client/model/PriorityRule.java
+++ b/src/main/java/org/maproulette/client/model/PriorityRule.java
@@ -1,23 +1,63 @@
 package org.maproulette.client.model;
 
 import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
 
-import lombok.AllArgsConstructor;
+import org.maproulette.client.exception.MapRouletteRuntimeParseException;
+
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
 /**
  * @author mcuthbert
  */
 @Builder
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+@Value
 public class PriorityRule implements Serializable
 {
+    private static final Set<String> NUMBER_COMPARISON_OPERATORS = Set.of("==", "!=", "<", "<=",
+            ">", ">=");
+    private static final Set<String> STRING_COMPARISON_OPERATORS = Set.of("equal", "not_equal",
+            "contains", "not_contains", "is_empty", "is_not_empty");
+    private static final Map<String, Set<String>> TYPE_TO_OPERATORS = Map.of("bounds",
+            Set.of("contains", "not_contains"), "string", STRING_COMPARISON_OPERATORS, "integer",
+            NUMBER_COMPARISON_OPERATORS, "long", NUMBER_COMPARISON_OPERATORS, "double",
+            NUMBER_COMPARISON_OPERATORS);
     private static final long serialVersionUID = -7443371611488972313L;
     private String value;
     private String type;
     private String operator;
+
+    public static PriorityRuleBuilder builder()
+    {
+        return new PriorityRuleBuilderCustom();
+    }
+
+    /**
+     * Extend the generated PriorityRuleBuilder for additional validation of the fields.
+     */
+    private static class PriorityRuleBuilderCustom extends PriorityRuleBuilder
+    {
+        public PriorityRule build()
+        {
+            if (!TYPE_TO_OPERATORS.containsKey(super.type))
+            {
+                throw new MapRouletteRuntimeParseException(
+                        String.format("Type '%s' is not supported by Priority Rules", super.type));
+            }
+            if (!TYPE_TO_OPERATORS.get(super.type).contains(super.operator))
+            {
+                throw new MapRouletteRuntimeParseException(String.format(
+                        "Operator '%s' is not supported by type '%s'", super.operator, super.type));
+            }
+            if (super.value.split("\\.").length != 2)
+            {
+                throw new MapRouletteRuntimeParseException(
+                        String.format("value '%s' must contain exactly one '.'", super.value));
+            }
+
+            return new PriorityRule(super.value, super.type, super.operator);
+        }
+    }
 }

--- a/src/test/java/org/maproulette/client/model/ChallengeTest.java
+++ b/src/test/java/org/maproulette/client/model/ChallengeTest.java
@@ -46,7 +46,7 @@ public class ChallengeTest
                 .instruction("TestInstruction")
                 .highPriorityRule(RuleList.builder().condition("AND")
                         .rules(Collections.singletonList(PriorityRule.builder().operator("equal")
-                                .type("string").value("testValue").build()))
+                                .type("string").value("test.value").build()))
                         .build())
                 .build();
         final var rule = challenge.getHighPriorityRule();
@@ -57,7 +57,7 @@ public class ChallengeTest
         final var onlyRule = ruleList.get(0);
         Assertions.assertEquals("equal", onlyRule.getOperator());
         Assertions.assertEquals("string", onlyRule.getType());
-        Assertions.assertEquals("testValue", onlyRule.getValue());
+        Assertions.assertEquals("test.value", onlyRule.getValue());
     }
 
     @Test

--- a/src/test/resources/rulelist/invalid/rulelist_missing_condition.json
+++ b/src/test/resources/rulelist/invalid/rulelist_missing_condition.json
@@ -1,0 +1,10 @@
+{
+  "_comment_": "The rulelist 'condition' is missing in this json. An exception should be thrown.",
+  "rules": [
+    {
+      "value": "priority_pd.3",
+      "type": "string",
+      "operator": "equal"
+    }
+  ]
+}

--- a/src/test/resources/rulelist/invalid/rulelist_missing_nested_all.json
+++ b/src/test/resources/rulelist/invalid/rulelist_missing_nested_all.json
@@ -1,0 +1,15 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "value": "t.u",
+      "type": "string",
+      "operator": "is_empty"
+    },
+    {
+      "_comment": "This object is not a RuleList and not a PriorityRule so an exception will be thrown",
+      "_MISSING_condition": "",
+      "_MISSING_rules": []
+    }
+  ]
+}

--- a/src/test/resources/rulelist/invalid/rulelist_missing_nested_condition.json
+++ b/src/test/resources/rulelist/invalid/rulelist_missing_nested_condition.json
@@ -1,0 +1,20 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "value": "t.u",
+      "type": "string",
+      "operator": "is_empty"
+    },
+    {
+      "_MISSING_condition": "",
+      "rules": [
+        {
+          "value": "a.b",
+          "type": "string",
+          "operator": "is_not_empty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/rulelist/invalid/rulelist_missing_nested_rules.json
+++ b/src/test/resources/rulelist/invalid/rulelist_missing_nested_rules.json
@@ -1,0 +1,14 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "value": "t.u",
+      "type": "string",
+      "operator": "is_empty"
+    },
+    {
+      "condition": "AND",
+      "_MISSING_rules": []
+    }
+  ]
+}

--- a/src/test/resources/rulelist/invalid/rulelist_nested_priorityrule_condition_typo.json
+++ b/src/test/resources/rulelist/invalid/rulelist_nested_priorityrule_condition_typo.json
@@ -1,0 +1,21 @@
+{
+  "condition": "AND",
+  "rules": [
+    {
+      "value": "t.u",
+      "type": "string",
+      "operator": "is_empty"
+    },
+    {
+      "_comment": "Lowercase 'or' is invalid and should throw an exception. It should have been 'OR'",
+      "condition": "or",
+      "rules": [
+        {
+          "value": "a.b",
+          "type": "string",
+          "operator": "is_not_empty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/rulelist/invalid/rulelist_priorityrule_condition_typo.json
+++ b/src/test/resources/rulelist/invalid/rulelist_priorityrule_condition_typo.json
@@ -1,0 +1,10 @@
+{
+  "condition": "aanddd",
+  "rules": [
+    {
+      "value": "priority_pd.3",
+      "type": "string",
+      "operator": "equal"
+    }
+  ]
+}


### PR DESCRIPTION
### Description:

The mr-java-client previously did not validate the Priority Rules (from builders, and serialization, and deserialization). This patch resolves those issues. Some of these patches should be implemented within the backend API's validation of Priority Rules...

### Unit Test Approach:

I created many new unit tests to focus on the (de)serialization of a RuleList and PriorityRule.
Some existing integration tests were broken since the backend requires 'equal' (not equals) and comparison op 'OR' (not 'or').

### Test Results:

The updated test pass fine.