### PR TITLE
rename maproulette2 to maproulette-backend

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,8 +28,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/checkout@v3
         with:
-          repository: 'maproulette/maproulette2'
-          path: 'maproulette2'
+          repository: 'maproulette/maproulette-backend'
+          path: 'maproulette-backend'
           fetch-depth: 0
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
@@ -53,13 +53,13 @@ jobs:
           pushd java-client
           ./gradlew build
 
-      - name: Build maproulette2 sbt
+      - name: Build maproulette-backend sbt
         run: |
-          pushd maproulette2
+          pushd maproulette-backend
           sbt compile
-      - name: Create the maproulette2 dev.conf
+      - name: Create the maproulette-backend dev.conf
         run: |
-          pushd maproulette2
+          pushd maproulette-backend
           touch ./conf/dev.conf
           echo 'include "application.conf"' >> ./conf/dev.conf
           echo 'db.default {' >> ./conf/dev.conf
@@ -81,7 +81,7 @@ jobs:
           scheme: http
           apiKey: 1234
         run: |
-          pushd maproulette2
+          pushd maproulette-backend
           sbt -Dconfig.file=./conf/dev.conf run &
           sleep 15
           popd


### PR DESCRIPTION
### Description:

The repo maproulette2 has been renamed to maproulette-backend.  fixing all associations in maproulette-java-client.

See https://github.com/maproulette/maproulette-backend

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](../CONTRIBUTING.md)
