### PR TITLE
Set 'useSystemProperties' on HttpClient builder

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgis11:
-        image: postgis/postgis:11-2.5
+        image: postgis/postgis:13-3.3
         ports:
           - 5432:5432
         env:

--- a/src/main/java/org/maproulette/client/http/HttpResource.java
+++ b/src/main/java/org/maproulette/client/http/HttpResource.java
@@ -141,7 +141,9 @@ public abstract class HttpResource implements Closeable
                 final var target = new HttpHost(this.uri.getHost(), this.uri.getPort(),
                         this.uri.getScheme());
                 final var context = HttpClientContext.create();
-                final var clientBuilder = HttpClients.custom();
+                // Create a builder that supports reading from system properties so things like
+                // proxies can be used with -Dhttp.proxyHost, -Dhttp.proxyPort.
+                final var clientBuilder = HttpClients.custom().useSystemProperties();
                 if (this.creds != null)
                 {
                     final var credsProvider = new BasicCredentialsProvider();


### PR DESCRIPTION
Set the httpClientBuilder.useSystemProperties() so that users may set the proxy settings via system properties eg

```
-Djava.net.useSystemProxies=true
-Dhttp.proxyHost=PROXY_HOST
-Dhttp.proxyPort=PROXY_PORT
-Dhttp.proxyUser=USERNAME
-Dhttp.proxyPassword=PASSWORD
```

