### PR TITLE
Use lombok 1.18.32 to support Java 17

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
           cache: 'gradle'
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v3
       - name: Publish maproulette-java-client
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Jdk 17 requires gradle 7.3+ https://docs.gradle.org/current/userguide/compatibility.html
-        java: [11]
+        java: [11, 17]
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
           path: 'maproulette-backend'
           fetch-depth: 0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -52,6 +52,7 @@ jobs:
           pushd maproulette-backend
           touch ./conf/dev.conf
           echo 'include "application.conf"' >> ./conf/dev.conf
+          echo 'play.http.secret.key = "GHACTION_9GcV9VDuy5JjYXBFldfD1Q+4/O8z2AAo3e9ID/tE9iM="' >> ./conf/dev.conf
           echo 'db.default {' >> ./conf/dev.conf
           echo '  url="jdbc:postgresql://localhost:5432/mr_test"' >> ./conf/dev.conf
           echo '  username="osm"' >> ./conf/dev.conf
@@ -88,4 +89,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v3

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     depJacksonVersion = "2.15.3"
     depJacocoVersion = "0.8.3"
     depJunitVersion = "5.10.2"
-    depLombokVersion = "1.18.16"
+    depLombokVersion = "1.18.32"
     depMockitoVersion = "5.11.0"
     depSlf4jVersion = "2.0.13"
 }


### PR DESCRIPTION
The MapRoulette-backend is starting to move to java 17 and it'll be nice to have the MR-java-client support compiling, tho maybe not publishing, using java 17.
